### PR TITLE
Fix displaying hex messages for personal_sign

### DIFF
--- a/src/components/DisplayRequest.tsx
+++ b/src/components/DisplayRequest.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import styled from "styled-components";
-import { convertHexToUtf8, convertHexToNumber } from "@walletconnect/utils";
+import { convertHexToNumber } from "@walletconnect/utils";
 import Column from "./Column";
 import Button from "./Button";
+import { convertHexToUtf8IfPossible } from "../helpers/utilities";
 
 const SRequestValues = styled.div`
   font-family: monospace;
@@ -93,7 +94,7 @@ class DisplayRequest extends React.Component<any, any> {
           { label: "Address", value: displayRequest.params[1] },
           {
             label: "Message",
-            value: convertHexToUtf8(displayRequest.params[0])
+            value: convertHexToUtf8IfPossible(displayRequest.params[0])
           }
         ];
         break;

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -1,3 +1,4 @@
+import { convertHexToUtf8 } from "@walletconnect/utils";
 import { IChainData } from "./types";
 import supportedChains from "./chains";
 
@@ -145,4 +146,12 @@ export function getViewportDimensions() {
   const y = w.innerHeight || e.clientHeight || g.clientHeight;
 
   return { x, y };
+}
+
+export function convertHexToUtf8IfPossible(hex: string) {
+  try {
+    return convertHexToUtf8(hex);
+  } catch(e) {
+    return hex;
+  }
 }


### PR DESCRIPTION
Without this, doing something like:

```
walletConnect.signPersonalMessage([ 
  "0x49aad05ee393812b8ab3d195cc9c41c5d2a0fa73634f3c5e72e0edb71e749a3d",
  myAddress
])
```

Results in a JS error:

```
Error: invalid utf8 byte sequence; unexpected continuation byte
(DisplayRequest.tsx line 96, convertHexToUtf8(displayRequest.params[0]))
```

This is perhaps not the most eloquent solution, but prevents the app from crashing anyway.