### PR TITLE
Fix signTransaction approval

### DIFF
--- a/src/controllers/wallet.ts
+++ b/src/controllers/wallet.ts
@@ -154,7 +154,9 @@ export class WalletController {
       if (data && data.from) {
         delete data.from;
       }
-      const result = await this.wallet.signMessage(data);
+      data.gasLimit = data.gas
+      delete data.gas
+      const result = await this.wallet.signTransaction(data);
       return result;
     } else {
       console.error("No Active Account");


### PR DESCRIPTION
When a `signTransaction` request is approved we use `signTransaction` instead of `signMessage` from the ethers signer.