### PR TITLE
Fix errors from missing signer and missing transaction params

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Test Wallet (Web)
 
+## Setup INFURA project id
+
+An INFURA project id is required to run this project. [Signup for a free INFURA project id here](https://infura.io/product/ethereum).
+
+Once you have the project id, setup the environment variable in file `.env.local` as follow.
+
+```
+REACT_APP_INFURA_PROJECT_ID=<your infura project id>
+```
+
 ## Develop
 
 ```bash

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -404,7 +404,16 @@ class App extends React.Component<{}> {
 
   public onQRCodeClose = () => this.toggleScanner();
 
-  public openRequest = (request: any) => this.setState({ payload: request });
+  public openRequest = async (request: any) => {
+    const payload = Object.assign({}, request);
+
+    const params = payload.params[0];
+    payload.params[0] = await getAppControllers().wallet.populateTransaction(params);
+
+    this.setState({
+      payload,
+    });
+  };
 
   public closeRequest = async () => {
     const { requests, payload } = this.state;

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -69,7 +69,7 @@ export function renderEthereumRequests(payload: any): IRequestRenderParams[] {
         },
         {
           label: "Value",
-          value: convertHexToNumber(payload.params[0].value),
+          value: payload.params[0].value ? convertHexToNumber(payload.params[0].value) : "",
         },
         { label: "Data", value: payload.params[0].data },
       ];

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -113,6 +113,10 @@ export function getChainData(chainId: number): IChainData {
 
   const API_KEY = process.env.REACT_APP_INFURA_PROJECT_ID;
 
+  if (!API_KEY) {
+    throw new Error("Environment variable REACT_APP_INFURA_PROJECT_ID is not set");
+  }
+
   if (
     chainData.rpc_url.includes("infura.io") &&
     chainData.rpc_url.includes("%API_KEY%") &&


### PR DESCRIPTION
I discovered the missing signer and transaction params issues while investigating the [ethers.js issue 1200](https://github.com/ethers-io/ethers.js/issues/1200).  

`wallet.connect(provider)` returns a new wallet instead of modifying the existing wallet object.  

`ethers` does not populate nonce, gasPrice, gasLimit when JsonRpcProvider is used.  (Web3Provider inherits from JsonRpcProvider).  

Following the convention that Geth/metamask, a JsonRpcProvider, would populate the nonce, gasPrice, and gasLimit if they are missing, I made a change to have wallet connect populate those fields if missing.

